### PR TITLE
Add module MCQ API

### DIFF
--- a/server/src/routes/course.routes.js
+++ b/server/src/routes/course.routes.js
@@ -6,6 +6,7 @@ const validateRequest = require("../middleware/validate-request");
 const checkRole = require("../middleware/check-role");
 const noteController = require("../controllers/noteController");
 
+
 const router = express.Router();
 
 // Validation middleware
@@ -150,6 +151,32 @@ router.delete(
   "/:courseId/modules/:moduleIndex/resources/:resourceIndex/notes/:noteId",
   protect,
   noteController.deleteNote
+);
+
+// Module MCQ Routes
+router.get(
+  "/:courseId/modules/:moduleId/mcq",
+  protect,
+  checkRole(["instructor", "admin"]),
+  courseController.getModuleMCQ
+);
+router.post(
+  "/:courseId/modules/:moduleId/mcq",
+  protect,
+  checkRole(["instructor", "admin"]),
+  courseController.addModuleQuiz
+);
+router.put(
+  "/:courseId/modules/:moduleId/mcq/:quizId",
+  protect,
+  checkRole(["instructor", "admin"]),
+  courseController.updateModuleQuiz
+);
+router.delete(
+  "/:courseId/modules/:moduleId/mcq/:quizId",
+  protect,
+  checkRole(["instructor", "admin"]),
+  courseController.deleteModuleQuiz
 );
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- support module MCQ CRUD in `course.controller`
- expose new module MCQ routes

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684a9a3c0394832b8a2c5fef04d44341